### PR TITLE
Fix undefined Date on Vitals - NEWS page

### DIFF
--- a/src/app/rippleui/pages/vitals/serviceVitalsSigns.js
+++ b/src/app/rippleui/pages/vitals/serviceVitalsSigns.js
@@ -361,7 +361,7 @@ class ServiceVitalsSigns {
           let _ = require('underscore');
           
           arr = _.sortBy(arr, function (value) {
-            return value.dateCreate;
+            return value.dateCreated;
           });
 
           for (var i = 0; i < arr.length; i++) {

--- a/src/app/rippleui/pages/vitals/vitals-detail.html
+++ b/src/app/rippleui/pages/vitals/vitals-detail.html
@@ -174,7 +174,7 @@
               <div class="col-expand-right">
                 <div class="form-group">
                   <label class="control-label">Date</label>
-                  <div class="form-control-static">{{ vital.dateCreate| date:'dd-MMM-yyyy'}}</div>
+                  <div class="form-control-static">{{ vital.dateCreated | date:'dd-MMM-yyyy'}}</div>
                 </div>
               </div>
             </div>

--- a/src/app/rippleui/pages/vitals/vitals-list.component.js
+++ b/src/app/rippleui/pages/vitals/vitals-list.component.js
@@ -83,7 +83,7 @@ class VitalsListController {
 
       /* istanbul ignore next  */
       for (var i = 0; i < vitals.length; i++) {
-        tempDate = formatDate(new Date(+vitals[i].dateCreate));
+        tempDate = formatDate(new Date(+vitals[i].dateCreated));
 
         if (lastDate === tempDate.date) {
           dataChart.labels.push(tempDate.time);
@@ -239,8 +239,8 @@ class VitalsListController {
         $scope.dateForChart = serviceVitalsSigns.modificateVitalsArr(data.vitals.data);
         $scope.vitals = angular.copy(data.vitals.data);
         
-        serviceFormatted.formattingTablesDate($scope.vitals, ['dateCreate'], serviceFormatted.formatCollection.DDMMMYYYY);
-        serviceFormatted.filteringKeys = ['id', 'dateCreate', 'newsScore', 'source'];
+        serviceFormatted.formattingTablesDate($scope.vitals, ['dateCreated'], serviceFormatted.formatCollection.DDMMMYYYY);
+        serviceFormatted.filteringKeys = ['id', 'dateCreated', 'newsScore', 'source'];
         
         usSpinnerService.stop('patientSummary-spinner');
 

--- a/src/app/rippleui/pages/vitals/vitals-list.html
+++ b/src/app/rippleui/pages/vitals/vitals-list.html
@@ -72,7 +72,7 @@
         <tbody>
           <tr dir-paginate="vital in vitals | filter: queryFiltering | orderBy:[order] : reverse | itemsPerPage: 10" current-page="currentPage" ng-click="go(vital.sourceId, vital)" ng-class="{info: selectedRow(vital.sourceId)}">
             <td data-th="#" ng-class="sortClass('id');"><span>{{ vital.id }}</span></td>
-            <td data-th="Date" ng-class="sortClass('date')"><span>{{ vital.dateCreate | date:'dd-MMM-yyyy' }}</span></td>
+            <td data-th="Date" ng-class="sortClass('date')"><span>{{ vital.dateCreated | date:'dd-MMM-yyyy' }}</span></td>
             <td data-th="NEWS Score" ng-class="sortClass('news')" class="highlighter-wrapper">
               <span>
                 <span ng-if="vital.statusNewsScore" ng-class="'highlighter-' + vital.statusNewsScore"></span>


### PR DESCRIPTION
There is the undefined date on Vitals - NEWS page.

<img width="572" alt="screen shot 2017-06-02 at 4 11 01 pm" src="https://cloud.githubusercontent.com/assets/1429230/26719253/016dfdd2-47ae-11e7-8ca3-7ff3343e57dd.png">

This pull request fixed this issue.

Best Regards.
Nam Vu from ThinksLabs-VN