### PR TITLE
Fix undefined Date on Images page

### DIFF
--- a/src/app/services/serviceFormatted.js
+++ b/src/app/services/serviceFormatted.js
@@ -34,6 +34,10 @@ class ServiceFormatted {
         if (angular.isNumber(date)) {
           return moment(date).format(format);
         } else {
+          var timestamp = Number(date);
+          if(!isNaN(timestamp)) {
+            return moment(timestamp).format(format);
+          }
           dateType = new Date(date).getTime();
           return moment(dateType).format(format);
         }


### PR DESCRIPTION
Hi PulseTile team,

I found the differences between the GT.M and Redis database for dateRecorded:
- GT.M return the timestamp number:

![pasted image at 2017_06_29 04_23 pm](https://user-images.githubusercontent.com/1429230/27791337-b90a35c2-601e-11e7-9e63-aee0a6dc081a.png)

- Redis return the timestamp string:

![pasted image at 2017_06_29 04_23 pm 1](https://user-images.githubusercontent.com/1429230/27791359-d53e43e6-601e-11e7-8b7b-07f7b58cea4e.png)

This pull request fixed the issue by converting timestamp string to number.

Regards,

Nam Vu from ThinkLabs-VN
